### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ tests/
 wren_modules
 .appends
 .gitignore
+.gitattributes

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ wren_modules
 .gitignore
 .gitattributes
 .dockerignore
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ bin/run-in-docker.sh
 bin/run-tests-in-docker.sh
 tests/
 wren_modules
+.appends

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ bin/run-tests-in-docker.sh
 tests/
 wren_modules
 .appends
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ wren_modules
 .appends
 .gitignore
 .gitattributes
+.dockerignore


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
