### PR TITLE
(chore) bump test-runner wren-console to v0.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM alpine:3.13
 RUN apk add --no-cache git build-base
 
 WORKDIR /tmp
-RUN git clone -b v0.2.91 --depth 2 https://github.com/joshgoebel/wren-console && \
+RUN git clone -b v0.3.1 --depth 2 https://github.com/joshgoebel/wren-console && \
     cd wren-console/deps && \
-    git clone -b v0.1.0 --depth 2 https://github.com/joshgoebel/wren-essentials && \
+    git clone -b v0.2.1 --depth 2 https://github.com/joshgoebel/wren-essentials && \
     cd .. && \
     make -j4 -C projects/make/
 


### PR DESCRIPTION
Bumps our test runner to Wren Console v0.3.1. (of which Wren Essentials v0.2.1 is a build dep)

If you know of any easy way to automate the version pinning, let me know... here is what I do on GitHub actions since it's a bit more flexible. (just cat the dependency into the ENV)

https://github.com/exercism/wren/pull/87/files