### PR TITLE
(fix) Testie.new should also use JSONReporter

### DIFF
--- a/wrappers/wren-testie/testie.wren
+++ b/wrappers/wren-testie/testie.wren
@@ -3,10 +3,13 @@ import "./json_reporter" for JSONReporter
 
 
 class Testie is TestieOrig {
-    construct new(name, fn) { super(name, fn) }
+    construct new(name, fn) {
+        self = super(name, fn)
+        self.reporter = JSONReporter
+        return self
+    }
     static test(name, fn) {
-        var tests = Testie.new(name,fn)
-        tests.reporter = JSONReporter
+        var tests = Testie.new(name, fn)
         tests.run()
     }
 }


### PR DESCRIPTION
This is the correct fix for #25.

Tests written with `Testie.new` vs `Testie.test` would break.  This resolves that issue.