### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   #   runs-on: <image-name>
 
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
   #     - name: Use <setup tooling>
   #       uses: <action to setup tooling>
   #       with:
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: install wren-console
-        uses: joshgoebel/install_wren_console@v1.0
+        uses: joshgoebel/install_wren_console@57ab2c4063656330e748b2cbd4beaeac30112a80
       - name: Checkout wren-test-runner
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
         with:
           path: test-runner
       - name: Install deps and run CI


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.